### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/colorfulclouds/sensor.py
+++ b/custom_components/colorfulclouds/sensor.py
@@ -82,7 +82,7 @@ class ColorfulcloudsSensor(Entity):
             "identifiers": {(DOMAIN, self.coordinator.data["location_key"])},
             "name": self._name,
             "manufacturer": MANUFACTURER,
-            "entry_type": "service",
+            "DeviceEntryType": "service",
         }
 
     @property
@@ -160,7 +160,7 @@ class ColorfulcloudsSensor(Entity):
         return SENSOR_TYPES[self.kind][self._unit_system]
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         # if self.forecast_day is not None:
         #     if self.kind in ["WindGustDay", "WindGustNight"]:


### PR DESCRIPTION
解决以下两个错误
Detected code that uses str for device registry entry_type. This is deprecated and will stop working in Home Assistant 2022.3, it should be updated to use DeviceEntryType instead. Please report this issue.
(<class 'custom_components.colorfulclouds.sensor.ColorfulcloudsSensor'>) implements device_state_attributes. Please report it to the custom component author.