### PR TITLE
Update weather.py

### DIFF
--- a/custom_components/colorfulclouds/weather.py
+++ b/custom_components/colorfulclouds/weather.py
@@ -101,7 +101,7 @@ class ColorfulCloudsEntity(WeatherEntity):
             "identifiers": {(DOMAIN, self.coordinator.data["location_key"])},
             "name": self._name,
             "manufacturer": MANUFACTURER,
-            "entry_type": "service",
+            "DeviceEntryType": "service",
         }
     @property
     def should_poll(self):


### PR DESCRIPTION
解决以下错误：
Detected code that uses str for device registry entry_type. This is deprecated and will stop working in Home Assistant 2022.3, it should be updated to use DeviceEntryType instead. Please report this issue.