### PR TITLE
Updates for HA 2022.3 or higher

### DIFF
--- a/custom_components/colorfulclouds/sensor.py
+++ b/custom_components/colorfulclouds/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.const import (
     DEVICE_CLASS_TEMPERATURE,
 )
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.device_registry import DeviceEntryType
 
 from .const import (
     ATTR_ICON,
@@ -82,7 +83,7 @@ class ColorfulcloudsSensor(Entity):
             "identifiers": {(DOMAIN, self.coordinator.data["location_key"])},
             "name": self._name,
             "manufacturer": MANUFACTURER,
-            "DeviceEntryType": "service",
+            "DeviceEntryType": DeviceEntryType.SERVICE,
         }
 
     @property

--- a/custom_components/colorfulclouds/weather.py
+++ b/custom_components/colorfulclouds/weather.py
@@ -4,6 +4,7 @@ import logging
 import json
 from datetime import datetime, timedelta
 
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.components.weather import (
     WeatherEntity, 
     ATTR_FORECAST_CONDITION, 
@@ -101,7 +102,7 @@ class ColorfulCloudsEntity(WeatherEntity):
             "identifiers": {(DOMAIN, self.coordinator.data["location_key"])},
             "name": self._name,
             "manufacturer": MANUFACTURER,
-            "DeviceEntryType": "service",
+            "DeviceEntryType": DeviceEntryType.SERVICE,
         }
     @property
     def should_poll(self):


### PR DESCRIPTION
- Device registry entry_type is deprecated and will stop working in Home Assistant 2022.3, it should be updated to use DeviceEntryType instead.