### PR TITLE
键名错误修改

### DIFF
--- a/custom_components/colorfulclouds/sensor.py
+++ b/custom_components/colorfulclouds/sensor.py
@@ -83,7 +83,7 @@ class ColorfulcloudsSensor(Entity):
             "identifiers": {(DOMAIN, self.coordinator.data["location_key"])},
             "name": self._name,
             "manufacturer": MANUFACTURER,
-            "DeviceEntryType": DeviceEntryType.SERVICE,
+            "entry_type": DeviceEntryType.SERVICE,
         }
 
     @property

--- a/custom_components/colorfulclouds/weather.py
+++ b/custom_components/colorfulclouds/weather.py
@@ -102,7 +102,7 @@ class ColorfulCloudsEntity(WeatherEntity):
             "identifiers": {(DOMAIN, self.coordinator.data["location_key"])},
             "name": self._name,
             "manufacturer": MANUFACTURER,
-            "DeviceEntryType": DeviceEntryType.SERVICE,
+            "entry_type": DeviceEntryType.SERVICE,
         }
     @property
     def should_poll(self):


### PR DESCRIPTION
我想你错误地理解了2022.3更新的说明，此处不是键名改为"DeviceEntryType"，而是entry_type的键值必须为DeviceEntryType的枚举型，上次提PR的时候没注意到你修改了键名。
见https://developers.home-assistant.io/docs/device_registry_index?_highlight=device_info#automatic-registration-through-an-entity中entry_type的说明“The type of entry. Possible values are None and DeviceEntryType enum members (only service).”