### PR TITLE
解决彩云API返回数据格式问题

### DIFF
--- a/custom_components/colorfulclouds/sensor.py
+++ b/custom_components/colorfulclouds/sensor.py
@@ -179,8 +179,14 @@ class ColorfulcloudsSensor(Entity):
             self._attrs["desc"] = self.coordinator.data["result"]["realtime"]["life_index"]["comfort"]["desc"]
         elif self.kind == "precipitation":
             self._attrs["datasource"] = self.coordinator.data["result"]["realtime"]["precipitation"]["local"]["datasource"]
-            self._attrs["nearest_intensity"] = self.coordinator.data["result"]["realtime"]["precipitation"]["nearest"]["intensity"]
-            self._attrs["nearest_distance"] = self.coordinator.data["result"]["realtime"]["precipitation"]["nearest"]["distance"]
+            #self._attrs["nearest_intensity"] = self.coordinator.data["result"]["realtime"]["precipitation"]["nearest"]["intensity"]
+            #self._attrs["nearest_distance"] = self.coordinator.data["result"]["realtime"]["precipitation"]["nearest"]["distance"]
+            if "nearest" in str(self.coordinator.data["result"]["realtime"]["precipitation"]):
+                self._attrs["nearest_intensity"] = self.coordinator.data["result"]["realtime"]["precipitation"]["nearest"]["intensity"]
+                self._attrs["nearest_distance"] = self.coordinator.data["result"]["realtime"]["precipitation"]["nearest"]["distance"]
+            else:
+                self._attrs["nearest_intensity"] = self.coordinator.data["result"]["realtime"]["precipitation"]["local"]["intensity"]
+                self._attrs["nearest_distance"] = self.coordinator.data["result"]["realtime"]["precipitation"]["local"]["datasource"]
         return self._attrs
 
     @property


### PR DESCRIPTION
最近彩云API返回数据格式经常发生缺少 'nearest'字段，致使hass报错日志如下：
Logger: homeassistant.components.sensor
Source: custom_components/colorfulclouds/sensor.py:184 Integration: 传感器 (documentation, issues)
First occurred: 22:36:00 (2 occurrences)
Last logged: 22:36:00

Error adding entities for domain sensor with platform colorfulclouds Error while setting up colorfulclouds platform for sensor Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 438, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 709, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 804, in add_to_platform_finish
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 556, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 600, in _async_write_ha_state
    attr.update(self.extra_state_attributes or {})
  File "/config/custom_components/colorfulclouds/sensor.py", line 184, in extra_state_attributes
    self._attrs["nearest_intensity"] = self.coordinator.data["result"]["realtime"]["precipitation"]["nearest"]["intensity"]
KeyError: 'nearest'
所使用的hass版本为：Home Assistant 2023.1.5
Supervisor 2022.12.1
前端版本： 20230110.0 - latest

加了个临时判断上去，这样可解决彩云api数据返回异常的问题。